### PR TITLE
Hotfix：修改维护人员后端

### DIFF
--- a/app/consts/errors.py
+++ b/app/consts/errors.py
@@ -18,8 +18,9 @@ ERROR_MAP = {
     10000021: u"企业信息未填写",
     10000022: u"该信息已经被修改",
     # info error
-    10000031: u""
+    10000031: u"",
     # data error
+    10000041: u"Json格式错误"
     # functional error code:
 
 }

--- a/app/libs/http.py
+++ b/app/libs/http.py
@@ -30,6 +30,5 @@ def jsonify_cors(raw=None, status_code=200):
 
 
 def error_jsonify_cors(error_code, specifiy_error="", status_code=400):
-    error_resp = compose_error(
-        specifiy_error if specifiy_error else ERROR_MAP[error_code], error_code)
+    error_resp = compose_error(specifiy_error if specifiy_error else ERROR_MAP[error_code], error_code)
     return jsonify_cors(error_resp, status_code)

--- a/app/libs/http.py
+++ b/app/libs/http.py
@@ -16,7 +16,8 @@ def jsonify(raw=None, status_code=200):
 
 
 def error_jsonify(error_code, specifiy_error="", status_code=400):
-    error_resp = compose_error(specifiy_error if specifiy_error else ERROR_MAP[error_code], error_code)
+    error_resp = compose_error(
+        specifiy_error if specifiy_error else ERROR_MAP[error_code], error_code)
     return jsonify(error_resp, status_code)
 
 

--- a/app/libs/http.py
+++ b/app/libs/http.py
@@ -30,5 +30,6 @@ def jsonify_cors(raw=None, status_code=200):
 
 
 def error_jsonify_cors(error_code, specifiy_error="", status_code=400):
-    error_resp = compose_error(specifiy_error if specifiy_error else ERROR_MAP[error_code], error_code)
+    error_resp = compose_error(
+        specifiy_error if specifiy_error else ERROR_MAP[error_code], error_code)
     return jsonify_cors(error_resp, status_code)

--- a/app/libs/http.py
+++ b/app/libs/http.py
@@ -16,8 +16,7 @@ def jsonify(raw=None, status_code=200):
 
 
 def error_jsonify(error_code, specifiy_error="", status_code=400):
-    error_resp = compose_error(
-        specifiy_error if specifiy_error else ERROR_MAP[error_code], error_code)
+    error_resp = compose_error(specifiy_error if specifiy_error else ERROR_MAP[error_code], error_code)
     return jsonify(error_resp, status_code)
 
 
@@ -32,5 +31,7 @@ def jsonify_cors(raw=None, status_code=200):
 
 def error_jsonify_cors(error_code, specifiy_error="", status_code=400):
     error_resp = compose_error(
-        specifiy_error if specifiy_error else ERROR_MAP[error_code], error_code)
+        specifiy_error if specifiy_error else ERROR_MAP[error_code],
+        error_code
+    )
     return jsonify_cors(error_resp, status_code)

--- a/app/libs/http.py
+++ b/app/libs/http.py
@@ -4,6 +4,11 @@ from app.libs.errorhandler import compose_error
 from app.consts.errors import ERROR_MAP
 
 
+jsonpickle.load_backend('json', 'dumps', 'loads', ValueError)
+jsonpickle.set_preferred_backend('json')
+jsonpickle.set_encoder_options('json', ensure_ascii=False)
+
+
 def jsonify(raw=None, status_code=200):
     resp = Response(jsonpickle.encode(raw), mimetype='application/json')
     resp.status_code = status_code
@@ -13,3 +18,18 @@ def jsonify(raw=None, status_code=200):
 def error_jsonify(error_code, specifiy_error="", status_code=400):
     error_resp = compose_error(specifiy_error if specifiy_error else ERROR_MAP[error_code], error_code)
     return jsonify(error_resp, status_code)
+
+
+def jsonify_cors(raw=None, status_code=200):
+    res = jsonify(raw, status_code)
+    res.headers['Access-Control-Allow-Origin'] = '*'
+    res.headers['Access-Control-Allow-Method'] = '*'
+    res.headers['Access-Control-Allow-Headers'] = '*'
+    res.headers['Content-Type'] = 'text/plain;charset=UTF-8'
+    return res
+
+
+def error_jsonify_cors(error_code, specifiy_error="", status_code=400):
+    error_resp = compose_error(specifiy_error if specifiy_error else ERROR_MAP[error_code], error_code)
+    return jsonify_cors(error_resp, status_code)
+

--- a/app/libs/http.py
+++ b/app/libs/http.py
@@ -30,6 +30,6 @@ def jsonify_cors(raw=None, status_code=200):
 
 
 def error_jsonify_cors(error_code, specifiy_error="", status_code=400):
-    error_resp = compose_error(specifiy_error if specifiy_error else ERROR_MAP[error_code], error_code)
+    error_resp = compose_error(
+        specifiy_error if specifiy_error else ERROR_MAP[error_code], error_code)
     return jsonify_cors(error_resp, status_code)
-

--- a/app/view/conversation_manager.py
+++ b/app/view/conversation_manager.py
@@ -4,7 +4,7 @@ import json
 from app.chatterbot.conversation import Statement
 from app.chatterbot.conversation import StatementRules
 from app.libs.chatbot import chatbot
-from app.libs.http import error_jsonify_cors, jsonify_cors
+from app.libs.http import error_jsonify, jsonify
 import traceback
 
 bp_manager = Blueprint('admin', __name__, url_prefix='/admin')
@@ -39,16 +39,16 @@ def admin_login():
     keys = ('username', 'password')
     req = {k: data[k] for k in keys if data.get(k) is not None}
     if not all(k in req for k in check_keys):
-        return error_jsonify_cors(10000001)
+        return error_jsonify(10000001)
 
     data = {'username': req['username'], 'userId': 1}
     if req['username'] == 'wechatterbot':
         if req['password'] == 'buaawechatterbot':
-            return jsonify_cors(data)
+            return jsonify(data)
         else:
-            return error_jsonify_cors(10000013)
+            return error_jsonify(10000013)
     else:
-        return error_jsonify_cors(10000012)
+        return error_jsonify(10000012)
 
 
 @bp_manager.route('/create_statement', methods=['POST'])
@@ -57,14 +57,14 @@ def create():
     try:
         data = json.loads(request.get_data(as_text=True))
     except ValueError:
-        return error_jsonify_cors(10000041)
+        return error_jsonify(10000041)
     except Exception:
         traceback.print_exc()
-        return error_jsonify_cors(10000002)
+        return error_jsonify(10000002)
 
     check_keys = ('text', 'response')
     if not all(k in data for k in check_keys):
-        return error_jsonify_cors(10000001)
+        return error_jsonify(10000001)
 
     s_text = data['text']
     s_response = data['response']
@@ -87,7 +87,7 @@ def create():
 
     # 调用数据接口
     result = {'code': code, 'statement': _statement2dict(new_statement)}
-    return jsonify_cors(result)
+    return jsonify(result)
 
 
 @bp_manager.route('/create_rule', methods=['POST'])
@@ -96,14 +96,14 @@ def create_rule():
     try:
         data = json.loads(request.get_data(as_text=True))
     except ValueError:
-        return error_jsonify_cors(10000041)
+        return error_jsonify(10000041)
     except Exception:
         traceback.print_exc()
-        return error_jsonify_cors(10000002)
+        return error_jsonify(10000002)
 
     check_keys = ('text', 'response')
     if not all(k in data for k in check_keys):
-        return error_jsonify_cors(10000001)
+        return error_jsonify(10000001)
 
     r_text = data['text']
     r_response = data['response']
@@ -121,7 +121,7 @@ def create_rule():
 
     # 调用数据接口
     data = {'code': code, 'rule': _rule2dict(new_rule)}
-    return jsonify_cors(data)
+    return jsonify(data)
 
 
 @bp_manager.route('/update_statement', methods=['POST'])
@@ -130,14 +130,14 @@ def update():
     try:
         data = json.loads(request.get_data(as_text=True))
     except ValueError:
-        return error_jsonify_cors(10000041)
+        return error_jsonify(10000041)
     except Exception:
         traceback.print_exc()
-        return error_jsonify_cors(10000002)
+        return error_jsonify(10000002)
 
     check_keys = ('id', 'text', 'response')
     if not all(k in data for k in check_keys):
-        return error_jsonify_cors(10000001)
+        return error_jsonify(10000001)
     s_id = data['id']
     text = data['text']
     response = data['response']
@@ -152,7 +152,7 @@ def update():
     db.update_text(new_statement)
     # 调用数据接口
     result = {'code': code, 'statement': _statement2dict(new_statement)}
-    return jsonify_cors(result)
+    return jsonify(result)
 
 
 @bp_manager.route('/update_rule', methods=['POST'])
@@ -161,14 +161,14 @@ def update_rule():
     try:
         data = json.loads(request.get_data(as_text=True))
     except ValueError:
-        return error_jsonify_cors(10000041)
+        return error_jsonify(10000041)
     except Exception:
         traceback.print_exc()
-        return error_jsonify_cors(10000002)
+        return error_jsonify(10000002)
 
     check_keys = ('text', 'response', 'id')
     if not all(k in data for k in check_keys):
-        return error_jsonify_cors(10000001)
+        return error_jsonify(10000001)
     r_id = data['id']
     text = data['text']
     response = data['response']
@@ -179,7 +179,7 @@ def update_rule():
     db.update_rule(new_rule)
     # 调用数据接口
     result = {'code': code, 'rule': _rule2dict(new_rule)}
-    return jsonify_cors(result)
+    return jsonify(result)
 
 
 @bp_manager.route('/search_statement', methods=['GET'])
@@ -192,7 +192,7 @@ def query():
     elif s_text is not None and s_text != '':
         statements = list(db.filter_text(text=s_text))
     else:
-        return error_jsonify_cors(10000001)
+        return error_jsonify(10000001)
     number = len(statements)
     code = 1
 
@@ -204,7 +204,7 @@ def query():
     # 调用数据接口
     data = {'code': code, 'number': number, 'statements': dict_statements}
     # print(data)
-    return jsonify_cors(data)
+    return jsonify(data)
 
 
 @bp_manager.route('/search_rule', methods=['GET'])
@@ -217,7 +217,7 @@ def query_rule():
     elif r_text != ''and r_text is not None:
         rules = list(db.filter_rules(text=r_text))
     else:
-        return error_jsonify_cors(10000001)
+        return error_jsonify(10000001)
     number = len(rules)
     code = 1
 
@@ -227,32 +227,32 @@ def query_rule():
 
     # 调用数据接口
     data = {'code': code, 'number': number, 'rules': dict_rules}
-    return jsonify_cors(data)
+    return jsonify(data)
 
 
 @bp_manager.route('/delete_statement', methods=['GET'])
 def delete_statement():
     statement_id = request.args.get("sid")
     if statement_id == '' or statement_id is None:
-        return error_jsonify_cors(10000001)
+        return error_jsonify(10000001)
     # 调用数据接口
     code = 1
     db.remove_text_by_id(statement_id)
 
     # 调用数据接口
     data = {'code': code}
-    return jsonify_cors(data)
+    return jsonify(data)
 
 
 @bp_manager.route('/delete_rule', methods=['GET'])
 def delete_rule():
     rule_id = request.args.get("rid")
     if rule_id == '' or rule_id is None:
-        return error_jsonify_cors(10000001)
+        return error_jsonify(10000001)
     # 调用数据接口
     code = 1
     db.remove_rules_by_id(rule_id)
 
     # 调用数据接口
     data = {'code': code}
-    return jsonify_cors(data)
+    return jsonify(data)

--- a/app/view/conversation_manager.py
+++ b/app/view/conversation_manager.py
@@ -60,6 +60,7 @@ def create():
         return error_jsonify_cors(10000041)
     except Exception:
         traceback.print_exc()
+        return error_jsonify_cors(10000002)
 
     check_keys = ('text', 'response')
     if not all(k in data for k in check_keys):
@@ -98,6 +99,7 @@ def create_rule():
         return error_jsonify_cors(10000041)
     except Exception:
         traceback.print_exc()
+        return error_jsonify_cors(10000002)
 
     check_keys = ('text', 'response')
     if not all(k in data for k in check_keys):
@@ -131,6 +133,7 @@ def update():
         return error_jsonify_cors(10000041)
     except Exception:
         traceback.print_exc()
+        return error_jsonify_cors(10000002)
 
     check_keys = ('id', 'text', 'response')
     if not all(k in data for k in check_keys):
@@ -139,7 +142,7 @@ def update():
     text = data['text']
     response = data['response']
     tag_list = []
-    if 'tag' in data:
+    if 'tags' in data:
         tags = data['tags']
         tag_list = tags.split('+')
     # 调用数据接口
@@ -161,8 +164,9 @@ def update_rule():
         return error_jsonify_cors(10000041)
     except Exception:
         traceback.print_exc()
+        return error_jsonify_cors(10000002)
 
-    check_keys = ('text', 'response','id')
+    check_keys = ('text', 'response', 'id')
     if not all(k in data for k in check_keys):
         return error_jsonify_cors(10000001)
     r_id = data['id']
@@ -203,7 +207,7 @@ def query():
     return jsonify_cors(data)
 
 
-@bp_manager.route('/search_rule')
+@bp_manager.route('/search_rule', methods=['GET'])
 def query_rule():
     r_text = request.args.get("text")
     r_id = request.args.get("id")
@@ -226,7 +230,7 @@ def query_rule():
     return jsonify_cors(data)
 
 
-@bp_manager.route('/delete_statement')
+@bp_manager.route('/delete_statement', methods=['GET'])
 def delete_statement():
     statement_id = request.args.get("sid")
     if statement_id == '' or statement_id is None:
@@ -240,7 +244,7 @@ def delete_statement():
     return jsonify_cors(data)
 
 
-@bp_manager.route('/delete_rule')
+@bp_manager.route('/delete_rule', methods=['GET'])
 def delete_rule():
     rule_id = request.args.get("rid")
     if rule_id == '' or rule_id is None:


### PR DESCRIPTION
进行了以下修改：

1. errors.py: 增加了新的错误类型

2. http.py: 
    2.1 更改了jsonpickle设置，使其直接返回中文数据。代码参考自[https://github.com/jsonpickle/jsonpickle/issues/13](url)
    2.2 保留了原有的两个方法，新增两个跨域方法。可直接通过修改header修改跨域策略。后期若无跨域问题，可直接调用原有方法。

3. conversation_manager.py:
    3.1 修改了数据库实例
    3.2 规范了返回的错误信息
    3.3 加入了接收数据格式的检查
    3.4 删除了部分不用的函数